### PR TITLE
FIx broken search on dir names with whitspace

### DIFF
--- a/scripts/xdg-open.in
+++ b/scripts/xdg-open.in
@@ -327,10 +327,12 @@ search_desktop_file()
             exit_success
         fi
     fi
-
+    SAVEIFS=$IFS
+    IFS=$(echo -en "\n\b")
     for d in "$dir/"*/; do
         [ -d "$d" ] && search_desktop_file "$default" "$d" "$target"
     done
+    IFS=$SAVEIFS
 }
 
 


### PR DESCRIPTION
it fixes the broken loop on dir names with whitspace:
this can cause to search in a different directories whic can lead to an infinite loop or termination with segmentation fault

a similar issue can be found here:
https://stackoverflow.com/questions/4895484